### PR TITLE
[Chapter 4] 예외

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@
 
 ### Chapter 3. 템플릿
 
-- [학습 브랜치]
-- [학습 기록]
+- [학습 브랜치](https://github.com/yeon-06/toby-spring/tree/chapter3)
+- [학습 기록](https://github.com/yeon-06/toby-spring/pull/5)
 
 ### Chapter 4. 예외
 
-- [학습 브랜치]
-- [학습 기록]
+- [학습 기록](https://github.com/yeon-06/toby-spring/pull/6)
 
 ### Chapter 5. 서비스 추상화
 

--- a/src/test/java/springbook/exception/ExceptionTest.java
+++ b/src/test/java/springbook/exception/ExceptionTest.java
@@ -1,0 +1,58 @@
+package springbook.exception;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class ExceptionTest {
+
+    @DisplayName(value = "예외 회피")
+    @Test
+    void avoid() {
+        // given & when & then
+        assertThatThrownBy(() -> checkNaturalNumber(-1))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @DisplayName(value = "예외 전환")
+    @Test
+    void change() {
+        // given & when & then
+        assertThatThrownBy(this::changeException)
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    void changeException() {
+        try {
+            checkNaturalNumber(-1);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("잘못된 인자를 넘겼습니다.");
+        }
+    }
+
+    @DisplayName(value = "예외 복구")
+    @Test
+    void recovery() {
+        // given & when & then
+        assertDoesNotThrow(this::recoverException);
+    }
+
+    void recoverException() {
+        try {
+            checkNaturalNumber(-1);
+        } catch (Exception e) {
+            // 정상 처리
+            checkNaturalNumber(1);
+        }
+    }
+
+    void checkNaturalNumber(final int number) throws RuntimeException {
+        if (number <= 0) {
+            throw new RuntimeException();
+        }
+    }
+}


### PR DESCRIPTION
# SQ3R

### ❓ 예외를 처리하는 방법 3가지
👉 예외 회피 / 전환 / 복구

- `회피`: 메서드에 `throws`를 달아 예외 처리하는 역할을 메서드를 호출한 쪽에게 맡기는 것
- `전환`: 적절한 예외로 변경하여 던지는 것
- `복구`: 예외 상황을 해결해 정상 상태로 돌려놓는 것

<br/>

### ❓ JdbcTemplate에서 SqlException이 사라진 이유
> 더 자세한 내용은 https://yeonyeon.tistory.com/215 참고

👉 더 구체적이고 적절한 예외로 변경하여 던져주고 있기 때문

<br/>

### ❓ DataAccessException의 계층 구조

![image](https://user-images.githubusercontent.com/53105735/193440772-38734ae5-9d8c-4b3d-ae8a-2f0ad14c5b11.png)

👉 RuntimeException을 상속하고 있으며 하위에 더 구체적이고 다양한 종류의 Exception들이 존재한다.

<br/>

# 후기
- 이전에 스프링에서는 왜 SqlException 처리를 안해줘도 될까에 대한 궁금증 때문에 이미 조사한 적 있는 부분이었다. 토비의 스프링에 같은 내용이 있을줄이야... 공부했던 내용과 겹치는 부분이 많아서 가벼운 마음으로 읽을 수 있었다.
- 많은 사람들이 사용하고 있는 Java라는 언어의 설계에서 잘못된 부분을 발견할때마다 신기하다. 완벽한 설계란 존재하지 않으며 다만 점차 발전하는 것임을 새삼 깨닫게 된다. 