### PR TITLE
[Chapter 5] 서비스 추상화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testImplementation 'org.springframework:spring-test:5.3.22'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }
 

--- a/sql/user_create.sql
+++ b/sql/user_create.sql
@@ -2,5 +2,6 @@ create table users
 (
     id       varchar(10) primary key,
     name     varchar(20) not null,
-    password varchar(10) not null
+    password varchar(10) not null,
+    level    int(4) not null
 );

--- a/src/main/java/springbook/jdbc/JdbcContext.java
+++ b/src/main/java/springbook/jdbc/JdbcContext.java
@@ -5,7 +5,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import javax.sql.DataSource;
-import springbook.domain.User;
 
 public class JdbcContext {
 

--- a/src/main/java/springbook/jdbc/User.java
+++ b/src/main/java/springbook/jdbc/User.java
@@ -1,0 +1,36 @@
+package springbook.jdbc;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class User {
+
+    private final String id;
+    private final String name;
+    private final String password;
+
+    public User(final String id, final String name, final String password) {
+        this.id = id;
+        this.name = name;
+        this.password = password;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(id, user.id) && Objects.equals(name, user.name)
+                && Objects.equals(password, user.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, password);
+    }
+}

--- a/src/main/java/springbook/jdbc/UserDao.java
+++ b/src/main/java/springbook/jdbc/UserDao.java
@@ -3,7 +3,6 @@ package springbook.jdbc;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import springbook.domain.User;
 
 public class UserDao {
 
@@ -19,14 +18,11 @@ public class UserDao {
     }
 
     public User findById(String id) {
-        StatementStrategy statementStrategy = new StatementStrategy() {
-            @Override
-            public PreparedStatement makePreparedStatement(final Connection connection) throws SQLException {
-                String sql = "select id, name, password from users where id = ?";
-                PreparedStatement preparedStatement = connection.prepareStatement(sql);
-                preparedStatement.setString(1, id);
-                return preparedStatement;
-            }
+        StatementStrategy statementStrategy = connection -> {
+            String sql = "select id, name, password from users where id = ?";
+            PreparedStatement preparedStatement = connection.prepareStatement(sql);
+            preparedStatement.setString(1, id);
+            return preparedStatement;
         };
 
         return jdbcContext.executeSelect(statementStrategy);

--- a/src/main/java/springbook/jdbctemplate/DataSourceConfig.java
+++ b/src/main/java/springbook/jdbctemplate/DataSourceConfig.java
@@ -7,14 +7,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 @Configuration
-public class DaoConfig {
+public class DataSourceConfig {
 
     @Bean
-    public UserDao userDao() {
-        return new UserDao(dataSource());
-    }
-
-    private DataSource dataSource() {
+    public DataSource dataSource() {
         SimpleDriverDataSource dataSource = new SimpleDriverDataSource();
         dataSource.setDriverClass(Driver.class);
         dataSource.setUrl("jdbc:mysql://localhost:13306/springbook");

--- a/src/main/java/springbook/jdbctemplate/Level.java
+++ b/src/main/java/springbook/jdbctemplate/Level.java
@@ -1,0 +1,28 @@
+package springbook.jdbctemplate;
+
+import java.util.Arrays;
+
+public enum Level {
+
+    BASIC(1),
+    SILVER(2),
+    GOLD(3),
+    ;
+
+    private final int value;
+
+    Level(final int value) {
+        this.value = value;
+    }
+
+    public static Level of(final int level) {
+        return Arrays.stream(Level.values())
+                .filter(it -> it.value == level)
+                .findAny()
+                .orElse(BASIC);
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/main/java/springbook/jdbctemplate/Level.java
+++ b/src/main/java/springbook/jdbctemplate/Level.java
@@ -22,6 +22,10 @@ public enum Level {
                 .orElse(BASIC);
     }
 
+    public Level nextLevel() {
+        return of(value + 1);
+    }
+
     public int getValue() {
         return value;
     }

--- a/src/main/java/springbook/jdbctemplate/Level.java
+++ b/src/main/java/springbook/jdbctemplate/Level.java
@@ -23,6 +23,9 @@ public enum Level {
     }
 
     public Level nextLevel() {
+        if (this == GOLD) {
+            return this;
+        }
         return of(value + 1);
     }
 

--- a/src/main/java/springbook/jdbctemplate/Level.java
+++ b/src/main/java/springbook/jdbctemplate/Level.java
@@ -24,7 +24,7 @@ public enum Level {
 
     public Level nextLevel() {
         if (this == GOLD) {
-            return this;
+            throw new IllegalStateException("더 업그레이드할 수 없는 레벨입니다.");
         }
         return of(value + 1);
     }

--- a/src/main/java/springbook/jdbctemplate/User.java
+++ b/src/main/java/springbook/jdbctemplate/User.java
@@ -9,13 +9,17 @@ public class User {
     private final String id;
     private final String name;
     private final String password;
-    private final Level level;
+    private Level level;
 
     public User(final String id, final String name, final String password, final Level level) {
         this.id = id;
         this.name = name;
         this.password = password;
         this.level = level;
+    }
+
+    public void upgradeLevel() {
+        level = level.nextLevel();
     }
 
     @Override

--- a/src/main/java/springbook/jdbctemplate/User.java
+++ b/src/main/java/springbook/jdbctemplate/User.java
@@ -1,4 +1,4 @@
-package springbook.domain;
+package springbook.jdbctemplate;
 
 import java.util.Objects;
 import lombok.Getter;

--- a/src/main/java/springbook/jdbctemplate/User.java
+++ b/src/main/java/springbook/jdbctemplate/User.java
@@ -9,11 +9,13 @@ public class User {
     private final String id;
     private final String name;
     private final String password;
+    private final Level level;
 
-    public User(final String id, final String name, final String password) {
+    public User(final String id, final String name, final String password, final Level level) {
         this.id = id;
         this.name = name;
         this.password = password;
+        this.level = level;
     }
 
     @Override

--- a/src/main/java/springbook/jdbctemplate/UserDao.java
+++ b/src/main/java/springbook/jdbctemplate/UserDao.java
@@ -12,7 +12,7 @@ public class UserDao {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
-    public void add(final User user) {
+    public void save(final User user) {
         String sql = "insert into users(id, name, password, level) values(?,?,?,?)";
         jdbcTemplate.update(sql, user.getId(), user.getName(), user.getPassword(), user.getLevel().getValue());
     }

--- a/src/main/java/springbook/jdbctemplate/UserDao.java
+++ b/src/main/java/springbook/jdbctemplate/UserDao.java
@@ -3,7 +3,6 @@ package springbook.jdbctemplate;
 import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import springbook.domain.User;
 
 public class UserDao {
 

--- a/src/main/java/springbook/jdbctemplate/UserDao.java
+++ b/src/main/java/springbook/jdbctemplate/UserDao.java
@@ -12,12 +12,12 @@ public class UserDao {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
-    public void add(User user) {
+    public void add(final User user) {
         String sql = "insert into users(id, name, password, level) values(?,?,?,?)";
         jdbcTemplate.update(sql, user.getId(), user.getName(), user.getPassword(), user.getLevel().getValue());
     }
 
-    public User findById(String id) {
+    public User findById(final String id) {
         String sql = "select id, name, password, level from users where id = ?";
         RowMapper<User> rowMapper = (rs, rowNum) -> new User(
                 rs.getString("id"),
@@ -26,6 +26,11 @@ public class UserDao {
                 Level.of(rs.getInt("level")));
 
         return jdbcTemplate.queryForObject(sql, rowMapper, id);
+    }
+
+    public void update(final User user) {
+        String sql = "update users set name = ?, password = ?, level = ? where id = ?";
+        jdbcTemplate.update(sql, user.getName(), user.getPassword(), user.getLevel().getValue(), user.getId());
     }
 
     public void deleteAll() {

--- a/src/main/java/springbook/jdbctemplate/UserDao.java
+++ b/src/main/java/springbook/jdbctemplate/UserDao.java
@@ -13,17 +13,17 @@ public class UserDao {
     }
 
     public void add(User user) {
-        String sql = "insert into users(id, name, password) values(?,?,?)";
-        jdbcTemplate.update(sql, user.getId(), user.getName(), user.getPassword());
+        String sql = "insert into users(id, name, password, level) values(?,?,?,?)";
+        jdbcTemplate.update(sql, user.getId(), user.getName(), user.getPassword(), user.getLevel().getValue());
     }
 
     public User findById(String id) {
-        String sql = "select id, name, password from users where id = ?";
+        String sql = "select id, name, password, level from users where id = ?";
         RowMapper<User> rowMapper = (rs, rowNum) -> new User(
                 rs.getString("id"),
                 rs.getString("name"),
-                rs.getString("password")
-        );
+                rs.getString("password"),
+                Level.of(rs.getInt("level")));
 
         return jdbcTemplate.queryForObject(sql, rowMapper, id);
     }

--- a/src/main/java/springbook/jdbctemplate/UserDao.java
+++ b/src/main/java/springbook/jdbctemplate/UserDao.java
@@ -3,7 +3,9 @@ package springbook.jdbctemplate;
 import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public class UserDao {
 
     private final JdbcTemplate jdbcTemplate;

--- a/src/main/java/springbook/jdbctemplate/UserService.java
+++ b/src/main/java/springbook/jdbctemplate/UserService.java
@@ -1,17 +1,42 @@
 package springbook.jdbctemplate;
 
+import java.sql.Connection;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 public class UserService {
 
     private final UserDao userDao;
+    private final DataSource dataSource;
 
-    public UserService(final UserDao userDao) {
-        this.userDao = userDao;
+    public UserService(final DataSource dataSource) {
+        this.dataSource = dataSource;
+        this.userDao = new UserDao(dataSource);
     }
 
-    public void upgradeLevel(User user) {
+    public void upgradeLevels(final List<User> users) throws Exception {
+        TransactionSynchronizationManager.initSynchronization();            // 동기화 작업 초기화
+        Connection connection = DataSourceUtils.getConnection(dataSource);  // DB 커넥션 생성 & 동기화 (=트랜잭션 시작)
+        try {
+            connection.setAutoCommit(false);
+            for (User user : users) {
+                upgradeLevel(user);
+            }
+            connection.commit();
+        } catch (IllegalStateException e) {
+            connection.rollback();
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);      // Connection 안전하게 close
+            TransactionSynchronizationManager.unbindResource(dataSource);
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    public void upgradeLevel(final User user) {
         user.upgradeLevel();
         userDao.update(user);
     }

--- a/src/main/java/springbook/jdbctemplate/UserService.java
+++ b/src/main/java/springbook/jdbctemplate/UserService.java
@@ -1,26 +1,23 @@
 package springbook.jdbctemplate;
 
 import java.util.List;
-import javax.sql.DataSource;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.jta.JtaTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 @Service
 public class UserService {
 
     private final UserDao userDao;
-    private final DataSource dataSource;
 
-    public UserService(final DataSource dataSource) {
-        this.dataSource = dataSource;
-        this.userDao = new UserDao(dataSource);
+    public UserService(final UserDao userDao) {
+        this.userDao = userDao;
     }
 
     public void upgradeLevels(final List<User> users) {
-        PlatformTransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
+        PlatformTransactionManager transactionManager = new JtaTransactionManager();
         TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
 
         try {

--- a/src/main/java/springbook/jdbctemplate/UserService.java
+++ b/src/main/java/springbook/jdbctemplate/UserService.java
@@ -1,0 +1,18 @@
+package springbook.jdbctemplate;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserDao userDao;
+
+    public UserService(final UserDao userDao) {
+        this.userDao = userDao;
+    }
+
+    public void upgradeLevel(User user) {
+        user.upgradeLevel();
+        userDao.update(user);
+    }
+}

--- a/src/test/java/springbook/jdbc/UserDaoTest.java
+++ b/src/test/java/springbook/jdbc/UserDaoTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import springbook.domain.User;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = DaoConfig.class)

--- a/src/test/java/springbook/jdbctemplate/LevelTest.java
+++ b/src/test/java/springbook/jdbctemplate/LevelTest.java
@@ -1,0 +1,21 @@
+package springbook.jdbctemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class LevelTest {
+
+    @ParameterizedTest(name = "{0}의 Level은 {1}")
+    @CsvSource(value = {"0,BASIC", "1,BASIC", "2,SILVER", "3,GOLD"})
+    void of(final int value, final Level expected) {
+        // given & when
+        Level level = Level.of(value);
+
+        // then
+        assertThat(level).isEqualTo(expected);
+    }
+}

--- a/src/test/java/springbook/jdbctemplate/LevelTest.java
+++ b/src/test/java/springbook/jdbctemplate/LevelTest.java
@@ -1,7 +1,10 @@
 package springbook.jdbctemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -18,12 +21,23 @@ class LevelTest {
     }
 
     @ParameterizedTest(name = "{0}의 다음 Level은 {1}")
-    @CsvSource(value = {"BASIC, SILVER", "SILVER,GOLD", "GOLD,GOLD"})
-    void of(final Level level, final Level expected) {
+    @CsvSource(value = {"BASIC, SILVER", "SILVER,GOLD"})
+    void nextLevel(final Level level, final Level expected) {
         // given & when
         Level nextLevel = level.nextLevel();
 
         // then
         assertThat(nextLevel).isEqualTo(expected);
+    }
+
+    @DisplayName(value = "업그레이드 불가능한 레벨")
+    @Test
+    void cannotUpgrade() {
+        // given
+        Level level = Level.GOLD;
+
+        // when & then
+        assertThatThrownBy(level::nextLevel)
+                .isInstanceOf(IllegalStateException.class);
     }
 }

--- a/src/test/java/springbook/jdbctemplate/LevelTest.java
+++ b/src/test/java/springbook/jdbctemplate/LevelTest.java
@@ -2,8 +2,6 @@ package springbook.jdbctemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -17,5 +15,15 @@ class LevelTest {
 
         // then
         assertThat(level).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "{0}의 다음 Level은 {1}")
+    @CsvSource(value = {"BASIC, SILVER", "SILVER,GOLD", "GOLD,GOLD"})
+    void of(final Level level, final Level expected) {
+        // given & when
+        Level nextLevel = level.nextLevel();
+
+        // then
+        assertThat(nextLevel).isEqualTo(expected);
     }
 }

--- a/src/test/java/springbook/jdbctemplate/UserDaoTest.java
+++ b/src/test/java/springbook/jdbctemplate/UserDaoTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import springbook.domain.User;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = DaoConfig.class)
@@ -27,7 +26,7 @@ class UserDaoTest {
     @Test
     void findById() {
         // given
-        User user = new User("id", "name", "1234");
+        User user = new User("id", "name", "1234", Level.SILVER);
         userDao.add(user);
 
         // when

--- a/src/test/java/springbook/jdbctemplate/UserDaoTest.java
+++ b/src/test/java/springbook/jdbctemplate/UserDaoTest.java
@@ -35,4 +35,22 @@ class UserDaoTest {
         // then
         assertThat(actual).isEqualTo(user);
     }
+
+    @DisplayName(value = "사용자 레벨 업그레이드")
+    @Test
+    void update() {
+        // given
+        String id = "yeonlog";
+        User user = new User(id, "name", "1234", Level.SILVER);
+        userDao.add(user);
+
+        user.upgradeLevel();
+
+        // when
+        userDao.update(user);
+
+        // then
+        User actual = userDao.findById(id);
+        assertThat(actual.getLevel()).isEqualTo(Level.SILVER.nextLevel());
+    }
 }

--- a/src/test/java/springbook/jdbctemplate/UserDaoTest.java
+++ b/src/test/java/springbook/jdbctemplate/UserDaoTest.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = DaoConfig.class)
+@ContextConfiguration(classes = {DataSourceConfig.class, UserDao.class})
 class UserDaoTest {
 
     @Autowired

--- a/src/test/java/springbook/jdbctemplate/UserDaoTest.java
+++ b/src/test/java/springbook/jdbctemplate/UserDaoTest.java
@@ -27,7 +27,7 @@ class UserDaoTest {
     void findById() {
         // given
         User user = new User("id", "name", "1234", Level.SILVER);
-        userDao.add(user);
+        userDao.save(user);
 
         // when
         User actual = userDao.findById(user.getId());
@@ -42,7 +42,7 @@ class UserDaoTest {
         // given
         String id = "yeonlog";
         User user = new User(id, "name", "1234", Level.SILVER);
-        userDao.add(user);
+        userDao.save(user);
 
         user.upgradeLevel();
 

--- a/src/test/java/springbook/jdbctemplate/UserServiceTest.java
+++ b/src/test/java/springbook/jdbctemplate/UserServiceTest.java
@@ -1,0 +1,58 @@
+package springbook.jdbctemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {DaoConfig.class, UserService.class})
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserDao userDao;
+
+    @BeforeEach
+    void delete() {
+        userDao.deleteAll();
+    }
+
+    @DisplayName(value = "사용자 레벨 정상 업그레이드")
+    @Test
+    void upgrade_success() {
+        // given
+        String id = "yeonlog06";
+        User user = new User(id, "연로그", "1234", Level.BASIC);
+        userDao.save(user);
+
+        // when
+        userService.upgradeLevel(user);
+
+        // then
+        User actual = userDao.findById(id);
+        assertThat(actual.getLevel()).isEqualTo(Level.SILVER);
+    }
+
+    @DisplayName(value = "사용자 레벨 업그레이드 실패")
+    @Test
+    void upgrade_failed() {
+        // given
+        String id = "yeonlog06";
+        User user = new User(id, "연로그", "1234", Level.GOLD);
+        userDao.save(user);
+
+        // when & then
+        assertThatThrownBy(() -> userService.upgradeLevel(user))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/springbook/jdbctemplate/UserServiceTest.java
+++ b/src/test/java/springbook/jdbctemplate/UserServiceTest.java
@@ -28,8 +28,29 @@ class UserServiceTest {
         userDao.deleteAll();
     }
 
+    @DisplayName(value = "여러명의 사용자 레벨 정상 업그레이드")
+    void upgradeLevels_succeed() throws Exception {
+        // given
+        User user1 = new User("id1", "name", "password", Level.BASIC);
+        User user2 = new User("id2", "name", "password", Level.BASIC);
+        User user3 = new User("id3", "name", "password", Level.SILVER);
+        List<User> users = List.of(user1, user2, user3);
+
+        // when
+        userService.upgradeLevels(users);
+
+        // then
+        User actual1 = userDao.findById(user1.getId());
+        User actual2 = userDao.findById(user2.getId());
+        User actual3 = userDao.findById(user3.getId());
+
+        assertThat(actual1.getLevel()).isEqualTo(Level.SILVER);
+        assertThat(actual2.getLevel()).isEqualTo(Level.SILVER);
+        assertThat(actual3.getLevel()).isEqualTo(Level.GOLD);
+    }
+
     @DisplayName(value = "하나라도 레벨 정상 업그레이드 되지 않으면 전부 롤백")
-    void upgradeLevels() throws Exception {
+    void upgradeLevels_failed() throws Exception {
         // given
         User user1 = new User("id1", "name", "password", Level.BASIC);
         User user2 = new User("id2", "name", "password", Level.BASIC);


### PR DESCRIPTION
(22.10.14)
## 💥해당 PR의 UserServiceTest는 잘못되었습니다.💥
👉 올바른 테스트는 Chapter 6에서 참고하시길 바랍니다.

***

# SQ3R

### ❓ ENUM의 사용 목적
> enum에 대한 설명은 예전에 [포스팅했던 글](https://yeonyeon.tistory.com/171)로 대체한다

👉 상수를 편리하고 의미 있는 형태로 관리할 수 있다. 잘못된 상수를 사용하는 경우 컴파일 에러를 띄울 수 있다.

<br/>

### ❓ JDBC 트랜잭션
👉 Connection 오브젝트를 이용해 트랜잭션의 시작과 종료를 지정할 수 있다. 자동 커밋 옵션을 false로 지정한 뒤 수동으로 커밋/롤백 시점을 정할수도 있다.

<br/>

### ❓ 트랜잭션 경계를 설정하는 방법
👉 트랜잭션을 적용할 시작 지점부터 끝 지점. 특정 범위 내의 로직을 하나의 작업으로 묶어 전부 commit 또는 rollback을 적용할지 지정할 수 있다. Connection 객체에서 setAutoCommit(false)를 통해 트랜잭션을 시작하고 commit() 또는 rollback()을 통해 트랜잭션을 종료할 수 있다.

<br/>

### ❓ 트랜잭션 동기화란?
👉 트랜잭션 시작을 위해 만든 Connection을 특별한 저장소에 보관해두었다 이후에 호출되는 로직에서 저장되었던 Connection을 사용하게 하는 것이다. 트랜잭션 동기화 저장소는 작업 스레드마다 독립적으로 Connection 오브젝트를 관리하기 때문에 멀티 스레드 환경에서 충돌의 걱정을 하지 않아도 된다.

<br/>

### ❓ JdbcTemplate의 트랜잭션 동기화
👉 트랜잭션 동기화 저장소에 등록된 DB Connection 또는 트랜잭션이 없는 경우에는 JdbcTemplate이 직접 DB Connection을 생성하고 트랜잭션을 시작해 JDBC 작업을 진행한다. 트랜잭션 동기화를 시작해두었다면 그때부터 실행되는 JdbcTemplate의 메서드에서는 트랜잭션 동기화 저장소에 들어있는 DB Connection을 가져와 사용한다.

<br/>

### ❓ 단일 책임 원칙이란
👉 하나의 모듈은 하나의 책임만 가져야한다는 원칙이다. 하나의 모듈이 바뀌는 이유는 단 한가지 뿐이어야 하며 변경이 일어나는 경우 수정 대상이 명확해진다.

<br/>

### ❓ 수직적인 계층 구조 vs 수평적인 계층 구조
👉 두 계층 구조 둘 다 로직을 나누면서 만들어낼 수 있다. 수직적인 계층 구조는 다른 계층의 특성을 갖는 코드를 분리한 것이다. 수평적인 계층 구조는 같은 애플리케이션 로직을 가진 코드지만 내용에 따라 분리한 것이다. (=같은 계층에서의 수평적인 분리)

<br/>

# 후기

- 이번에는 처음 들어보는 내용이 조금씩 나왔다. 실무에서 여러 자원을 한 트랜잭션에서 관리해야하는 경우에는 JTA를 이용하는가? JTA 외의 다른 방법을 통해 제어할 수도 있는가?
- MailSender를 서비스 추상화하는 작업은 최근 진행중인 프로젝트인 [줍줍](https://github.com/woowacourse-teams/2022-pickpick)에서 Slack의 라이브러리를 추상화하던 작업과 동일해서 읽어보기만 했다. 나 스스로 이렇게 로직 짜는게 더 편하겠다라고 생각한 로직이 책에 그대로 나와있어 신기했다 ㅎ.ㅎ
- 트랜잭션에 대한 이야기가 잠시 나와서 `@Transactional`에 대한 이야기도 나올까 기대했는데 디테일하게 나오진 않아서 좀 아쉬웠다. 뒤에 이야기가 나오지 않을까?